### PR TITLE
Add optional manual password and token for auth

### DIFF
--- a/charts/chromadb-chart/templates/config.yaml
+++ b/charts/chromadb-chart/templates/config.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  token: {{ randAlphaNum 32 | b64enc | quote }}
+  token: {{ .Values.chromadb.auth.token.value | default ( randAlphaNum 32 ) | b64enc | quote }}
   {{- if eq .Values.chromadb.auth.token.headerType "AUTHORIZATION" }}
   header: {{ "Authorization" | b64enc | quote}}
   {{- end }}
@@ -33,6 +33,6 @@ metadata:
 type: Opaque
 data:
   username: {{ .Values.chromadb.auth.basic.username | b64enc | quote}}
-  password: {{ randAlphaNum 16 | b64enc | quote }}
+  password: {{ .Values.chromadb.auth.basic.password | default ( randAlphaNum 16 ) | b64enc | quote }}
 {{- end }}
 ---

--- a/charts/chromadb-chart/templates/statefulset.yaml
+++ b/charts/chromadb-chart/templates/statefulset.yaml
@@ -18,6 +18,9 @@ spec:
         {{- include "chart.labels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }} # Automatically Roll Deployments
+      {{- with .Values.podSpec.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       securityContext: {{ toYaml .Values.podSpec.securityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.podSpec.terminationGracePeriodSeconds }}

--- a/charts/chromadb-chart/templates/statefulset.yaml
+++ b/charts/chromadb-chart/templates/statefulset.yaml
@@ -16,6 +16,8 @@ spec:
     metadata:
       labels:
         {{- include "chart.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }} # Automatically Roll Deployments
     spec:
       securityContext: {{ toYaml .Values.podSpec.securityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.podSpec.terminationGracePeriodSeconds }}

--- a/charts/chromadb-chart/values.yaml
+++ b/charts/chromadb-chart/values.yaml
@@ -70,6 +70,7 @@ affinity: { }
 podSpec:
   terminationGracePeriodSeconds: 5
   securityContext: { }
+  podAnnotations: { }
   # capabilities:
   #   drop:
   #   - ALL

--- a/charts/chromadb-chart/values.yaml
+++ b/charts/chromadb-chart/values.yaml
@@ -112,6 +112,7 @@ chromadb:
     type: "token" # possible values: basic, token
     basic:
       username: "chroma"
+      password: null  # The string used as the auth.basic password. Only used if value not null, otherwise a random string will be generated and used.
       config:
         env:
           - name: CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER
@@ -122,6 +123,7 @@ chromadb:
             value: "/chroma/auth/server.htpasswd"
     token:
       headerType: "AUTHORIZATION" #possible values AUTHORIZATION, X_CHROMA_TOKEN
+      value: null # The string used as the token (value). Only used if value not null, otherwise a random string will be generated and used.
       config:
         env:
           - name: CHROMA_SERVER_AUTH_CREDENTIALS


### PR DESCRIPTION
Two fields have been added to the values.yaml of the chromadb-chart. The 'password' field for basic authentication and the 'value' field for token.
When these fields are not null, their corresponding authentication methods will use the provided string instead of generating a random string as a credential. They are null by default.
This change allows users to manually set their credentials and improve the system's flexibility.
