### PR TITLE
Add NodePort and initImage to values

### DIFF
--- a/charts/chromadb-chart/templates/service.yaml
+++ b/charts/chromadb-chart/templates/service.yaml
@@ -11,6 +11,8 @@ spec:
       targetPort: {{ .Values.chromadb.serverHttpPort }}
       protocol: TCP
       name: http
+      {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}

--- a/charts/chromadb-chart/templates/service.yaml
+++ b/charts/chromadb-chart/templates/service.yaml
@@ -11,5 +11,6 @@ spec:
       targetPort: {{ .Values.chromadb.serverHttpPort }}
       protocol: TCP
       name: http
+      nodePort: {{ .Values.service.nodePort }}
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}

--- a/charts/chromadb-chart/templates/statefulset.yaml
+++ b/charts/chromadb-chart/templates/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
       {{- if and (semverCompare ">= 0.4.7" .Values.chromadb.apiVersion) .Values.chromadb.auth.enabled (eq .Values.chromadb.auth.type "basic") }}
       initContainers:
         - name: generate-htpasswd
-          image: docker.io/httpd:2
+          image: {{ .Values.initImage }}
           env:
             - name: CHROMA_BASIC_USER
               valueFrom:

--- a/charts/chromadb-chart/templates/statefulset.yaml
+++ b/charts/chromadb-chart/templates/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
       {{- if and (semverCompare ">= 0.4.7" .Values.chromadb.apiVersion) .Values.chromadb.auth.enabled (eq .Values.chromadb.auth.type "basic") }}
       initContainers:
         - name: generate-htpasswd
-          image: httpd:2
+          image: docker.io/httpd:2
           env:
             - name: CHROMA_BASIC_USER
               valueFrom:

--- a/charts/chromadb-chart/values.yaml
+++ b/charts/chromadb-chart/values.yaml
@@ -27,7 +27,7 @@ serviceAccount:
 
 
 service:
-  type: NodePort #use ClusterIP for internal only and LoadBalancer for external
+  type: ClusterIP  # ClusterIP, NodePort, LoadBalancer
   nodePort: null
 
 ingress:

--- a/charts/chromadb-chart/values.yaml
+++ b/charts/chromadb-chart/values.yaml
@@ -9,6 +9,9 @@ image:
 #  repository: ghcr.io/amikos-tech/chromadb-chart/chroma
   pullPolicy: IfNotPresent
 
+# initContainer image
+initImage: docker.io/httpd:2
+
 imagePullSecrets: [ ]
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/chromadb-chart/values.yaml
+++ b/charts/chromadb-chart/values.yaml
@@ -25,6 +25,7 @@ serviceAccount:
 
 service:
   type: NodePort #use ClusterIP for internal only and LoadBalancer for external
+  nodePort: null
 
 ingress:
   enabled: false


### PR DESCRIPTION
Hi!
One of the issues I faced while using this excellent Helm chart was the inability to select the NodePort. Additionally, since the initContainer image was set to httpd:2, it caused deployment problems on some clusters. I added these two options to the values. I hope you find them useful
Best regards
Mojtaba