### PR TITLE
fix: allow to override default config/log_config.yaml by a custom one

### DIFF
--- a/charts/chromadb-chart/templates/config.yaml
+++ b/charts/chromadb-chart/templates/config.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   log_config.yaml: |-
-    {{- .Files.Get "config/log_config.yaml" | nindent 4 }}
+    {{- .Files.Get .Values.chromadb.logConfigFileLocation | nindent 4 }}
 ---
 {{- if and .Values.chromadb.auth.enabled (eq .Values.chromadb.auth.type "token") (eq .Values.chromadb.auth.existingSecret "") }}
 apiVersion: v1

--- a/charts/chromadb-chart/templates/statefulset.yaml
+++ b/charts/chromadb-chart/templates/statefulset.yaml
@@ -113,10 +113,8 @@ spec:
             - name: CHROMA_SERVER_HTTP_PORT
               value: "{{ .Values.chromadb.serverHttpPort }}"
             {{- end }}
-            {{- if .Values.chromadb.logConfigFileLocation }}
             - name: CHROMA_LOG_CONFIG
-              value: "{{ .Values.chromadb.logConfigFileLocation }}"
-            {{- end }}
+              value: "chromadb/log_config.yml"
             {{- if and  .Values.chromadb.auth.enabled (eq .Values.chromadb.auth.type "token") }}
             {{- if and (semverCompare ">= 0.4.7" (include "chromadb.apiVersion" .)) (semverCompare "< 0.5.0" (include "chromadb.apiVersion" .)) }}
             - name: CHROMA_SERVER_AUTH_CREDENTIALS

--- a/charts/chromadb-chart/templates/statefulset.yaml
+++ b/charts/chromadb-chart/templates/statefulset.yaml
@@ -114,7 +114,7 @@ spec:
               value: "{{ .Values.chromadb.serverHttpPort }}"
             {{- end }}
             - name: CHROMA_LOG_CONFIG
-              value: "chromadb/log_config.yml"
+              value: "/chroma/log_config.yaml"
             {{- if and  .Values.chromadb.auth.enabled (eq .Values.chromadb.auth.type "token") }}
             {{- if and (semverCompare ">= 0.4.7" (include "chromadb.apiVersion" .)) (semverCompare "< 0.5.0" (include "chromadb.apiVersion" .)) }}
             - name: CHROMA_SERVER_AUTH_CREDENTIALS

--- a/charts/chromadb-chart/values.yaml
+++ b/charts/chromadb-chart/values.yaml
@@ -103,7 +103,7 @@ chromadb:
   allowReset: false
   isPersistent: true
   persistDirectory: /index_data
-  logConfigFileLocation: /chroma/log_config.yaml
+  logConfigFileLocation: config/log_config.yaml
   anonymizedTelemetry: false
   corsAllowOrigins:
     - "*" # TODO this might be dangerous


### PR DESCRIPTION
Right now is not possible to replace the default config/log_config.yaml file. 
So I think the value `logConfigFileLocation` should be used as path to render the configmap.