### PR TITLE
feat: expose new Rust v1 config options in ConfigMap

### DIFF
--- a/charts/chromadb-chart/values.yaml
+++ b/charts/chromadb-chart/values.yaml
@@ -137,6 +137,16 @@ chromadb:
     enabled: false
     endpoint: ""
     serviceName: "chroma"
+    filters: []
+  # Rust v1 config options (>= 1.0.0)
+  sqliteFilename: ""
+  sqliteDb:
+    hashType: "" # supported values: md5, sha256
+    migrationMode: "" # supported values: apply, validate
+  circuitBreaker:
+    requests: null # 0 disables the circuit breaker
+  segmentManager:
+    hnswIndexPoolCacheConfig: {}
   maintenance:
     collection_cache_policy: null # possible values: null or "LRU"
     collection_cache_limit_bytes: 1000000000 # defaults to 1GB. TODO: this must also observe limits if defined
@@ -152,7 +162,5 @@ chromadb:
       value: null # The string used as the token (value). Only used if value not null, otherwise a random string will be generated and used.
   # Extra config keys merged into the v1 server config (>= 1.0.0). Overrides chart-managed keys.
   extraConfig: {}
-    # circuit_breaker:
-    #   requests: 500
-    # sqlite_filename: "chroma.sqlite3"
-
+    # compactor:
+    #   disabled_collections: []


### PR DESCRIPTION
## Summary
- expose dedicated Helm values for Rust v1 server config options used in production (sqliteFilename, sqliteDb, circuitBreaker, telemetry.filters, segmentManager.hnswIndexPoolCacheConfig)
- render those values into v1-config with validation for enum/range/type constraints
- keep extraConfig as override/escape hatch and clarify this behavior in README
- gate Rust v1-only dedicated options to chromadb.apiVersion >= 1.0.0
- expand tests/test_v1_config.sh with boundary/behavior coverage (defaults absence, requests=0, case normalization, telemetry+filters coexistence, extraConfig precedence, pre-1.0 omission)

## Validation
- bash tests/test_v1_config.sh (57 passed, 0 failed)

Closes #125