### PR TITLE
chore(release): prepare chart 0.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ The chart supports multiple ChromaDB versions from 0.4.3 to 1.0.x with version-s
 
 ## Important Notes
 
-- Default ChromaDB version is 1.5.0 (as of chart version 0.1.25)
+- Default ChromaDB version is 1.5.0 (as of chart version 0.2.0)
 - Authentication is NOT supported in ChromaDB 1.0.x - use network-level security or API gateway
 - Data persistence is enabled by default at `/data` directory
 - Anonymous telemetry is disabled by default for privacy

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ To use the chart as a dependency, add the following to your `Chart.yaml` file:
 ```yaml
 dependencies:
   - name: chromadb
-    version: 0.1.24
+    version: 0.2.0
     repository: "https://amikos-tech.github.io/chromadb-chart/"
 ```
 

--- a/charts/chromadb-chart/Chart.yaml
+++ b/charts/chromadb-chart/Chart.yaml
@@ -16,5 +16,5 @@ keywords:
   - ai/ml
 type: application
 
-version: 0.1.26
+version: 0.2.0
 appVersion: "1.5.0"


### PR DESCRIPTION
## Summary
- bump Helm chart version to 0.2.0
- update dependency example version in README
- align internal docs to reference 0.2.0

## Validation
- helm lint charts/chromadb-chart