### PR TITLE
Validate chart parameters for #96

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Example `values.yaml` file:
 
 ```yaml
 chromadb:
-  allowReset: "true"
+  allowReset: true
 ```
 
 Alternatively you can specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 ```bash
-helm install chroma chroma/chromadb --set chromadb.allowReset="true"
+helm install chroma chroma/chromadb --set chromadb.allowReset=true
 ```
 
 ## Chart Configuration Values
@@ -62,9 +62,9 @@ helm install chroma chroma/chromadb --set chromadb.allowReset="true"
 | Key                                                 | Type    | Default                               | Description                                                                                                                                                                                                                                                                                                |
 |-----------------------------------------------------|---------|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `chromadb.apiVersion`                               | string  | `1.5.0` (Chart app version)           | The ChromaDB version. Supported version `0.4.3` - `1.x`                                                                                                                                                                                                                                                    |
-| `chromadb.allowReset`                               | boolean | `false`                               | Allows resetting the index (delete all data)                                                                                                                                                                                                                                                               |
-| `chromadb.isPersistent`                             | boolean | `true`                                | `< 1.0.0`: controls PVC plus `IS_PERSISTENT` server mode. `>= 1.0.0`: controls only PVC creation/mounting for `persistDirectory`; the Rust server always writes to disk, so data is ephemeral without a PVC.                                                                                           |
-| `chromadb.persistDirectory`                         | string  | `/data`                               | The location to store the index data. This configure both chromadb and underlying persistent volume                                                                                                                                                                                                        |
+| `chromadb.allowReset`                               | boolean | `false`                               | Allows resetting the index (delete all data). Accepts bool or string `true`/`false` (case-insensitive); rendered value is normalized to lowercase.                                                                                                                                                        |
+| `chromadb.isPersistent`                             | boolean | `true`                                | `< 1.0.0`: controls PVC plus `IS_PERSISTENT` server mode. `>= 1.0.0`: controls only PVC creation/mounting for `persistDirectory`; the Rust server always writes to disk, so data is ephemeral without a PVC. Accepts bool or string `true`/`false` (case-insensitive); rendered value is normalized to lowercase. |
+| `chromadb.persistDirectory`                         | string  | `/data`                               | Absolute path where index data is stored. Used for both Chroma server config and mounted persistent volume path.                                                                                                                                                                                            |
 | `chromadb.anonymizedTelemetry`                      | boolean | `false`                               | Legacy PostHog telemetry flag for `< 1.0.0`. **Note**: This has no effect in Chroma `>= 1.0.0`; use `chromadb.telemetry.*` for OTEL.                                                                                                                                                                      |
 | `chromadb.corsAllowOrigins`                         | list    | `[]`                                  | List of allowed CORS origins. Wildcard `["*"]` is supported.                                                                                                                                                                                                                                               |
 | `chromadb.apiImpl`                                  | string  | `- "chromadb.api.segment.SegmentAPI"` | Legacy/removed key kept for historical compatibility in docs. The chart does not read this value in current versions.                                                                                                                                                                                     |

--- a/charts/chromadb-chart/templates/statefulset.yaml
+++ b/charts/chromadb-chart/templates/statefulset.yaml
@@ -1,3 +1,7 @@
+{{- $allowReset := include "chromadb.allowReset" . -}}
+{{- $isPersistentStr := include "chromadb.isPersistent" . -}}
+{{- $isPersistent := eq $isPersistentStr "true" -}}
+{{- $persistDirectory := include "chromadb.persistDirectory" . -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -86,11 +90,11 @@ spec:
                   fieldPath: metadata.name
             {{- if and (semverCompare "< 1.0.0" (include "chromadb.apiVersion" .)) }}
             - name: IS_PERSISTENT
-              value: "{{ .Values.chromadb.isPersistent }}"
+              value: "{{ $isPersistentStr }}"
             - name: PERSIST_DIRECTORY
-              value: "{{ .Values.chromadb.persistDirectory }}"
+              value: "{{ $persistDirectory }}"
             - name: ALLOW_RESET
-              value: "{{ .Values.chromadb.allowReset | default false}}"
+              value: "{{ $allowReset }}"
             - name: ANONYMIZED_TELEMETRY
               value: "{{ .Values.chromadb.anonymizedTelemetry | default false }}"
             {{- if .Values.chromadb.corsAllowOrigins }}
@@ -164,8 +168,8 @@ spec:
               name: log-config-legacy
               subPath: log_config.yaml
             {{- end }}
-            {{- if eq .Values.chromadb.isPersistent true }}
-            - mountPath: "{{.Values.chromadb.persistDirectory}}"
+            {{- if $isPersistent }}
+            - mountPath: "{{ $persistDirectory }}"
               name: data
             {{- end }}
             {{- if and (semverCompare "< 1.0.0" (include "chromadb.apiVersion" .)) (semverCompare ">= 0.4.7" (include "chromadb.apiVersion" .)) .Values.chromadb.auth.enabled (eq .Values.chromadb.auth.type "basic") }}
@@ -225,7 +229,7 @@ spec:
             name: v1-config
             defaultMode: 0644
         {{- end }}
-  {{- if eq .Values.chromadb.isPersistent true }}
+  {{- if $isPersistent }}
   volumeClaimTemplates:
     - metadata:
         name: data


### PR DESCRIPTION
## Summary
- add Helm template validation helpers for `chromadb.allowReset`, `chromadb.isPersistent`, and `chromadb.persistDirectory`
- accept booleans or case-insensitive string booleans for `allowReset`/`isPersistent`, normalize rendered values to lowercase
- enforce `chromadb.persistDirectory` as a non-empty absolute path
- wire normalized values through statefulset env/PVC/mount rendering and v1 config generation
- add regression tests for valid/invalid inputs and update docs/examples

## Validation
- `bash tests/ci_smoke.sh`

Closes #96
