### PR TITLE
feat: add nginx reverse-proxy and tls config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,20 @@ helm install chroma chroma/chromadb --set chromadb.allowReset=true
 | `commonLabels`                                      | object  | `{}`                                  | Additional labels applied to all chart resources (StatefulSet, Service, Ingress, ConfigMaps, Secrets, PVCs, test Jobs).                                                                                                                                                                                    |
 | `podLabels`                                         | object  | `{}`                                  | Additional labels applied to pods only. Does not affect `matchLabels`.                                                                                                                                                                                                                                     |
 
+## Nginx Configuration Values
+
+| Key                                         | Type    | Default                        | Description                                                                                |
+| ------------------------------------------- | ------- | ------------------------------ | ------------------------------------------------------------------------------------------ |
+| `nginx.enabled`                             | boolean | `false`                        | Enable / disable the NGINX proxy sidecar.                                                  |
+| `nginx.image`                               | string  | `docker.io/library/nginx:1.23` | NGINX container image (registry + repository + tag).                                       |
+| `nginx.imagePullPolicy`                     | string  | `Always`                       | Image pull policy.                                                                         |
+| `nginx.resources`                           | object  | `{}`                           | Resource requests/limits for the NGINX container.                                          |
+| `nginx.containerPorts.http`                 | int     | `80`                          | Port exposed by nginx when `tls.enabled` is false.            |
+| `nginx.containerPorts.https`                 | int     | `443`                          | Port exposed by nginx when `tls.enabled` is true.            |
+| `nginx.tls.enabled`                         | boolean | `true`                         | Enable TLS termination inside the NGINX container (expects `chromadb-tls` secret mounted). |
+| `nginx.containerSecurityContext.enabled`    | boolean | `false`                        | Enable custom security context for the NGINX container.                                    |
+| `nginx.containerSecurityContext.secContext` | object  | see values.yaml                | SecurityContext spec applied if `containerSecurityContext.enabled` is `true`.              |
+
 ### Legacy values for `< 1.0.0`
 
 For Chroma `>= 1.0.0` (Rust server), the chart keeps the following values only for backward compatibility and ignores them:

--- a/charts/chromadb-chart/templates/_helpers.tpl
+++ b/charts/chromadb-chart/templates/_helpers.tpl
@@ -76,6 +76,36 @@ Returns the proper initImage name.
 {{- end }}
 
 {{/*
+Returns the proper nginx name.
+*/}}
+{{- define "chart.images.nginx" -}}
+{{- $registryName := default .Values.nginx.image.registry ((.Values.global).imageRegistry) -}}
+{{- $repositoryName := .Values.nginx.image.repository -}}
+{{- $separator := ":" -}}
+{{- $termination := .Values.nginx.image.tag | toString -}}
+{{- if .Values.nginx.image.digest -}}
+    {{- $separator = "@" -}}
+    {{- $termination = .Values.nginx.image.digest | toString -}}
+{{- end -}}
+{{- if $registryName -}}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- else -}}
+    {{- printf "%s%s%s"  $repositoryName $separator $termination -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Returns the nginx port based on TLS configuration
+*/}}
+{{- define "chromadb.nginx.port" -}}
+{{- if .Values.nginx.tls.enabled -}}
+{{- .Values.nginx.containerPorts.https -}}
+{{- else -}}
+{{- .Values.nginx.containerPorts.http -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "chart.labels" -}}

--- a/charts/chromadb-chart/templates/config.yaml
+++ b/charts/chromadb-chart/templates/config.yaml
@@ -174,3 +174,36 @@ metadata:
 data:
   config.yaml: |-
     {{- include "chromadb.serverConfig" . | nindent 4 }}
+---
+{{- if .Values.nginx.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chart.fullname" . }}-nginx
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+data:
+  nginx.conf: |
+    server {
+        {{- if .Values.nginx.tls.enabled }}
+        listen {{ include "chromadb.nginx.port" . }} ssl;
+        ssl_certificate     /etc/nginx/certs/tls.crt;
+        ssl_certificate_key /etc/nginx/certs/tls.key;
+        {{- else }}
+        listen {{ include "chromadb.nginx.port" . }};
+        {{- end }}
+
+        client_max_body_size 40M;
+
+        location / {
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
+            proxy_pass http://127.0.0.1:{{ .Values.chromadb.serverHttpPort }};
+        }
+    }
+{{- end }}

--- a/charts/chromadb-chart/templates/service.yaml
+++ b/charts/chromadb-chart/templates/service.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.chromadb.serverHttpPort }}
-      targetPort: {{ .Values.chromadb.serverHttpPort }}
+    - port: {{ .Values.nginx.enabled | ternary (include "chromadb.nginx.port" .) .Values.chromadb.serverHttpPort }}
+      targetPort: {{ .Values.nginx.enabled | ternary (include "chromadb.nginx.port" .) .Values.chromadb.serverHttpPort }}
       protocol: TCP
       name: http
       {{- if .Values.service.nodePort }}

--- a/charts/chromadb-chart/templates/statefulset.yaml
+++ b/charts/chromadb-chart/templates/statefulset.yaml
@@ -71,6 +71,64 @@ spec:
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       containers:
+        {{- if .Values.nginx.enabled }}
+        - name: nginx
+          image: "{{ include "chart.images.nginx" . }}"
+          imagePullPolicy: {{ .Values.nginx.imagePullPolicy }}
+          {{- if .Values.nginx.resources }}
+          resources: {{ toYaml .Values.nginx.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.nginx.containerSecurityContext.enabled }}
+          securityContext: {{ toYaml .Values.nginx.containerSecurityContext.secContext | nindent 12 }}
+          {{- end }}
+          {{- if .Values.nginx.livenessProbe.enabled }}
+          livenessProbe: {{ toYaml (omit .Values.nginx.livenessProbe "enabled") | nindent 12 }}
+          {{- end }}
+          {{- if .Values.nginx.readinessProbe.enabled }}
+          readinessProbe: {{ toYaml (omit .Values.nginx.readinessProbe "enabled") | nindent 12 }}
+          {{- end }}
+          {{- if .Values.nginx.startupProbe.enabled }}
+          startupProbe: {{ toYaml (omit .Values.nginx.startupProbe "enabled") | nindent 12 }}
+          {{- end }}
+          env:
+            - name: TZ
+              value: "Europe/Paris"
+          ports:
+            - name: {{ .Values.nginx.tls.enabled | ternary "https" "http" }}
+              containerPort: {{ include "chromadb.nginx.port" . }}
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+            {{- if .Values.nginx.tls.enabled }}
+            - name: certs
+              readOnly: true
+              mountPath: /etc/nginx/certs
+            {{- end }}
+          {{- if .Values.nginx.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ include "chromadb.nginx.port" . }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          {{- end }}
+          {{- if .Values.nginx.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ include "chromadb.nginx.port" . }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          {{- end }}
+          {{- if .Values.nginx.startupProbe.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: {{ include "chromadb.nginx.port" . }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+          {{- end }}
+        {{- end }}
         - name: "chromadb"
           image: "{{ include "chart.images.chroma" . }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
@@ -229,6 +287,19 @@ spec:
           configMap:
             name: v1-config
             defaultMode: 0644
+        {{- end }}
+        {{- if .Values.nginx.enabled }}
+        - name: nginx-config
+          configMap:
+            name: {{ include "chart.fullname" . }}-nginx
+            defaultMode: 0644
+        {{- end }}
+        {{- if .Values.nginx.tls.enabled }}
+        {{- $default := printf "%s-nginx-tls" (include "chart.fullname" .) -}}
+        {{- $secretName := .Values.nginx.tls.secretName | default $default }}
+        - name: certs
+          secret:
+            secretName: {{ $secretName }}
         {{- end }}
   {{- if $isPersistent }}
   volumeClaimTemplates:

--- a/charts/chromadb-chart/templates/tests/test-api.yaml
+++ b/charts/chromadb-chart/templates/tests/test-api.yaml
@@ -18,7 +18,14 @@ spec:
           command: ['curl']
           args:
             - '-v'
+            {{- if .Values.nginx.enabled }}
+            {{- if .Values.nginx.tls.enabled }}
+            - '-k'
+            {{- end }}
+            - 'http{{ .Values.nginx.tls.enabled | ternary "s" "" }}://{{ include "chart.fullname" . }}:{{ include "chromadb.nginx.port" . }}/api/v1/collections'
+            {{- else }}
             - 'http://{{ include "chart.fullname" . }}:{{ .Values.chromadb.serverHttpPort }}/api/v1/collections'
+            {{- end }}
             {{- if and (semverCompare "< 1.0.0" (include "chromadb.apiVersion" .)) .Values.chromadb.auth.enabled (eq .Values.chromadb.auth.type "token") }}
             {{- $existingConfigMap := (lookup "v1" "ConfigMap" .Release.Namespace (include "chart.fullname" . | printf "%s-token-auth-config")) }}
             {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (.Values.chromadb.auth.existingSecret | default "chromadb-auth")) }}

--- a/charts/chromadb-chart/templates/tests/test-connection.yaml
+++ b/charts/chromadb-chart/templates/tests/test-connection.yaml
@@ -18,7 +18,14 @@ spec:
           command: ['curl']
           args:
             - '-v'
+            {{- if .Values.nginx.enabled }}
+            {{- if .Values.nginx.tls.enabled }}
+            - '-k'
+            {{- end }}
+            - 'http{{ .Values.nginx.tls.enabled | ternary "s" "" }}://{{ include "chart.fullname" . }}:{{ include "chromadb.nginx.port" . }}/api/v1/hearbeat'
+            {{- else }}
             - 'http://{{ include "chart.fullname" . }}:{{ .Values.chromadb.serverHttpPort }}/api/v1/hearbeat'
+            {{- end }}
             {{- if and (semverCompare "< 1.0.0" (include "chromadb.apiVersion" .)) .Values.chromadb.auth.enabled (eq .Values.chromadb.auth.type "token") }}
             {{- $existingConfigMap := (lookup "v1" "ConfigMap" .Release.Namespace (include "chart.fullname" . | printf "%s-token-auth-config")) }}
             {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (.Values.chromadb.auth.existingSecret | default "chromadb-auth")) }}

--- a/charts/chromadb-chart/values.yaml
+++ b/charts/chromadb-chart/values.yaml
@@ -175,3 +175,46 @@ chromadb:
   extraConfig: {}
     # compactor:
     #   disabled_collections: []
+
+nginx:
+  enabled: false
+  image:
+    repository: docker.io/library/nginx
+    tag: "1.23"
+  imagePullPolicy: Always
+  resources: {}
+  containerPorts:
+    http: 80
+    https: 443
+  tls:
+    enabled: true
+    secretName: ""
+  readinessProbe:
+    enabled: true
+    failureThreshold: 20
+    timeoutSeconds: 10
+    periodSeconds: 5
+  livenessProbe:
+    enabled: true
+    failureThreshold: 40
+    timeoutSeconds: 10
+    periodSeconds: 5
+  startupProbe:
+    enabled: true
+    failureThreshold: 1000
+    periodSeconds: 5
+    initialDelaySeconds: 10
+  containerSecurityContext:
+    enabled: false
+    secContext:
+      seLinuxOptions: {}
+      runAsUser: 1001
+      runAsGroup: 1001
+      runAsNonRoot: true
+      privileged: false
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"


### PR DESCRIPTION
Hey @tazarov,
I worked on the TLS part using an nginx proxy as recommended in the [chroma docs](https://cookbook.chromadb.dev/security/ssl-proxies/).