### PR TITLE
chore: support Chroma 1.5.2 as chart + CI default

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 env:
-  LATEST_VERSION: "1.5.0"
+  LATEST_VERSION: "1.5.2"
 jobs:
   integration-test:
     strategy:
@@ -28,7 +28,7 @@ jobs:
         chroma-version:
           [
             0.6.3,
-            1.5.0,
+            1.5.2,
           ]
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ helm test chromadb
 
 # GitHub Actions integration tests run on:
 # - Kubernetes versions: 1.28.0, 1.33.1, 1.35.1
-# - Chroma versions: 0.6.3, 1.5.0
+# - Chroma versions: 0.6.3, 1.5.2
 ```
 
 ### Local Development with Minikube
@@ -86,7 +86,7 @@ The chart supports multiple ChromaDB versions from 0.4.3 to 1.0.x with version-s
 
 ## Important Notes
 
-- Default ChromaDB version is 1.5.0 (as of chart version 0.2.0)
+- Default ChromaDB version is 1.5.2 (as of chart version 0.2.1)
 - Authentication is NOT supported in ChromaDB 1.0.x - use network-level security or API gateway
 - Data persistence is enabled by default at `/data` directory
 - Anonymous telemetry is disabled by default for privacy

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ helm install chroma chroma/chromadb --set chromadb.allowReset=true
 
 | Key                                                 | Type    | Default                               | Description                                                                                                                                                                                                                                                                                                |
 |-----------------------------------------------------|---------|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `chromadb.apiVersion`                               | string  | `1.5.0` (Chart app version)           | The ChromaDB version. Supported version `0.4.3` - `1.x`                                                                                                                                                                                                                                                    |
+| `chromadb.apiVersion`                               | string  | `1.5.2` (Chart app version)           | The ChromaDB version. Supported version `0.4.3` - `1.x`                                                                                                                                                                                                                                                    |
 | `chromadb.allowReset`                               | boolean | `false`                               | Allows resetting the index (delete all data). Accepts bool or string `true`/`false` (case-insensitive); rendered value is normalized to lowercase.                                                                                                                                                        |
 | `chromadb.isPersistent`                             | boolean | `true`                                | `< 1.0.0`: controls PVC plus `IS_PERSISTENT` server mode. `>= 1.0.0`: controls only PVC creation/mounting for `persistDirectory`; the Rust server always writes to disk, so data is ephemeral without a PVC. Accepts bool or string `true`/`false` (case-insensitive); rendered value is normalized to lowercase. |
 | `chromadb.persistDirectory`                         | string  | `/data`                               | Absolute path where index data is stored. Used for both Chroma server config and mounted persistent volume path.                                                                                                                                                                                            |
@@ -259,7 +259,7 @@ To use the chart as a dependency, add the following to your `Chart.yaml` file:
 ```yaml
 dependencies:
   - name: chromadb
-    version: 0.2.0
+    version: 0.2.1
     repository: "https://amikos-tech.github.io/chromadb-chart/"
 ```
 

--- a/charts/chromadb-chart/Chart.yaml
+++ b/charts/chromadb-chart/Chart.yaml
@@ -16,5 +16,5 @@ keywords:
   - ai/ml
 type: application
 
-version: 0.2.0
-appVersion: "1.5.0"
+version: 0.2.1
+appVersion: "1.5.2"

--- a/tests/ci_smoke.sh
+++ b/tests/ci_smoke.sh
@@ -21,7 +21,7 @@ helm lint "$CHART_DIR"
 
 echo "==> Rendering v1-config with integration extraConfig values"
 config="$(helm template test "$CHART_DIR" \
-  --set chromadb.apiVersion=1.5.0 \
+  --set chromadb.apiVersion=1.5.2 \
   --set chromadb.extraConfig.scorecard_enabled=true \
   --set chromadb.extraConfig.circuit_breaker.requests=500 \
   | yq eval 'select(.metadata.name == "v1-config") | .data["config.yaml"]' -)"

--- a/tests/test_v1_config.sh
+++ b/tests/test_v1_config.sh
@@ -193,7 +193,7 @@ assert_equal "CHROMA_SERVER_HTTP_PORT is default 8000 on < 1.0.0" "$server_http_
 
 echo ""
 echo "15. Custom serverHttpPort on >= 1.0.0 does not create legacy env var"
-server_http_port_env=$(get_statefulset_env_value "CHROMA_SERVER_HTTP_PORT" --set 'chromadb.apiVersion=1.5.0' --set 'chromadb.serverHttpPort=9000')
+server_http_port_env=$(get_statefulset_env_value "CHROMA_SERVER_HTTP_PORT" --set 'chromadb.apiVersion=1.5.2' --set 'chromadb.serverHttpPort=9000')
 assert_equal "CHROMA_SERVER_HTTP_PORT remains absent on >= 1.0.0 with custom port" "$server_http_port_env" "null"
 
 echo ""
@@ -326,6 +326,11 @@ assert_template_fails "persistDirectory rejects relative paths" \
   --set-string 'chromadb.persistDirectory=data'
 assert_template_fails "persistDirectory rejects empty strings" \
   --set-string 'chromadb.persistDirectory='
+
+echo ""
+echo "34. Default image uses latest chart appVersion"
+default_image=$(get_statefulset_value '.spec.template.spec.containers[] | select(.name == "chromadb") | .image')
+assert_equal "default image tag is 1.5.2" "$default_image" "ghcr.io/chroma-core/chroma:1.5.2"
 
 echo ""
 echo "--- Results: $PASS passed, $FAIL failed ---"


### PR DESCRIPTION
## Summary
- bump chart `appVersion` to `1.5.2` and chart version to `0.2.1`
- update integration CI latest version and matrix from `1.5.0` to `1.5.2`
- align smoke/template tests and docs to `1.5.2`
- add a template test assertion that default rendered image is `ghcr.io/chroma-core/chroma:1.5.2`

## Validation
- `bash tests/ci_smoke.sh`

Closes #137
