### PR TITLE
chore: bump chart baseline to Chroma 1.5.3

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 env:
-  LATEST_VERSION: "1.5.2"
+  LATEST_VERSION: "1.5.3"
 jobs:
   integration-test:
     strategy:
@@ -28,7 +28,7 @@ jobs:
         chroma-version:
           [
             0.6.3,
-            1.5.2,
+            1.5.3,
           ]
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ helm test chromadb
 
 # GitHub Actions integration tests run on:
 # - Kubernetes versions: 1.28.0, 1.33.1, 1.35.1
-# - Chroma versions: 0.6.3, 1.5.2
+# - Chroma versions: 0.6.3, 1.5.3
 ```
 
 ### Local Development with Minikube
@@ -86,7 +86,7 @@ The chart supports multiple ChromaDB versions from 0.4.3 to 1.0.x with version-s
 
 ## Important Notes
 
-- Default ChromaDB version is 1.5.2 (as of chart version 0.2.1)
+- Default ChromaDB version is 1.5.3 (as of chart version 0.2.2)
 - Authentication is NOT supported in ChromaDB 1.0.x - use network-level security or API gateway
 - Data persistence is enabled by default at `/data` directory
 - Anonymous telemetry is disabled by default for privacy

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ helm install chroma chroma/chromadb --set chromadb.allowReset=true
 
 | Key                                                 | Type    | Default                               | Description                                                                                                                                                                                                                                                                                                |
 |-----------------------------------------------------|---------|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `chromadb.apiVersion`                               | string  | `1.5.2` (Chart app version)           | The ChromaDB version. Supported version `0.4.3` - `1.x`                                                                                                                                                                                                                                                    |
+| `chromadb.apiVersion`                               | string  | `1.5.3` (Chart app version)           | The ChromaDB version. Supported version `0.4.3` - `1.x`                                                                                                                                                                                                                                                    |
 | `chromadb.allowReset`                               | boolean | `false`                               | Allows resetting the index (delete all data). Accepts bool or string `true`/`false` (case-insensitive); rendered value is normalized to lowercase.                                                                                                                                                        |
 | `chromadb.isPersistent`                             | boolean | `true`                                | `< 1.0.0`: controls PVC plus `IS_PERSISTENT` server mode. `>= 1.0.0`: controls only PVC creation/mounting for `persistDirectory`; the Rust server always writes to disk, so data is ephemeral without a PVC. Accepts bool or string `true`/`false` (case-insensitive); rendered value is normalized to lowercase. |
 | `chromadb.persistDirectory`                         | string  | `/data`                               | Absolute path where index data is stored. Used for both Chroma server config and mounted persistent volume path.                                                                                                                                                                                            |
@@ -259,7 +259,7 @@ To use the chart as a dependency, add the following to your `Chart.yaml` file:
 ```yaml
 dependencies:
   - name: chromadb
-    version: 0.2.1
+    version: 0.2.2
     repository: "https://amikos-tech.github.io/chromadb-chart/"
 ```
 

--- a/charts/chromadb-chart/Chart.yaml
+++ b/charts/chromadb-chart/Chart.yaml
@@ -16,5 +16,5 @@ keywords:
   - ai/ml
 type: application
 
-version: 0.2.1
-appVersion: "1.5.2"
+version: 0.2.2
+appVersion: "1.5.3"

--- a/tests/ci_smoke.sh
+++ b/tests/ci_smoke.sh
@@ -21,7 +21,7 @@ helm lint "$CHART_DIR"
 
 echo "==> Rendering v1-config with integration extraConfig values"
 config="$(helm template test "$CHART_DIR" \
-  --set chromadb.apiVersion=1.5.2 \
+  --set chromadb.apiVersion=1.5.3 \
   --set chromadb.extraConfig.scorecard_enabled=true \
   --set chromadb.extraConfig.circuit_breaker.requests=500 \
   | yq eval 'select(.metadata.name == "v1-config") | .data["config.yaml"]' -)"

--- a/tests/test_v1_config.sh
+++ b/tests/test_v1_config.sh
@@ -193,7 +193,7 @@ assert_equal "CHROMA_SERVER_HTTP_PORT is default 8000 on < 1.0.0" "$server_http_
 
 echo ""
 echo "15. Custom serverHttpPort on >= 1.0.0 does not create legacy env var"
-server_http_port_env=$(get_statefulset_env_value "CHROMA_SERVER_HTTP_PORT" --set 'chromadb.apiVersion=1.5.2' --set 'chromadb.serverHttpPort=9000')
+server_http_port_env=$(get_statefulset_env_value "CHROMA_SERVER_HTTP_PORT" --set 'chromadb.apiVersion=1.5.3' --set 'chromadb.serverHttpPort=9000')
 assert_equal "CHROMA_SERVER_HTTP_PORT remains absent on >= 1.0.0 with custom port" "$server_http_port_env" "null"
 
 echo ""
@@ -330,7 +330,7 @@ assert_template_fails "persistDirectory rejects empty strings" \
 echo ""
 echo "34. Default image uses latest chart appVersion"
 default_image=$(get_statefulset_value '.spec.template.spec.containers[] | select(.name == "chromadb") | .image')
-assert_equal "default image tag is 1.5.2" "$default_image" "ghcr.io/chroma-core/chroma:1.5.2"
+assert_equal "default image tag is 1.5.3" "$default_image" "ghcr.io/chroma-core/chroma:1.5.3"
 
 echo ""
 echo "--- Results: $PASS passed, $FAIL failed ---"


### PR DESCRIPTION
## Summary
- bump the chart package to 0.2.2 and set the default Chroma app version to 1.5.3
- update CI, smoke tests, and v1 config assertions to treat 1.5.3 as the latest supported v1 release
- align README examples and contributor notes with the new chart/app versions

Closes #139

## Validation
- bash tests/ci_smoke.sh
- verified the rendered default image tag is ghcr.io/chroma-core/chroma:1.5.3
- verify .github/workflows/integration-test.yml still gates extraConfig checks on the latest-version lane via matrix.chroma-version == env.LATEST_VERSION